### PR TITLE
align benchmark_pics in the middle

### DIFF
--- a/app/assets/stylesheets/benchmark_pics/_new.scss
+++ b/app/assets/stylesheets/benchmark_pics/_new.scss
@@ -1,5 +1,8 @@
 .benchmark-container {
   justify-content: center;
+  height: 100vh;
+  display: flex;
+  align-items : center;
 
   .simple_form {
     text-align: center;


### PR DESCRIPTION
I changed the css for the benchmark_pics/new and now be able to see the contents in the middle of the page